### PR TITLE
fix(main: convert timestamp to ISO format in EventGenerator

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,14 +19,15 @@ import signal
 import sys
 import time
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 import cv2
 from numpy.typing import NDArray
 
 from backend.camera_stream import CameraConnectionError, CameraStream
-from backend.config import Settings, ModelSettings, get_config
-from backend.database import EventDatabase, DatabaseError
+from backend.config import ModelSettings, Settings, get_config
+from backend.database import DatabaseError, EventDatabase
 from backend.detection_models import DetectionResult
 from backend.detector import DetectionError, ModelLoadError, VehicleDetector
 
@@ -153,7 +154,9 @@ class EventGenerator:
 
         event = {
             "eventId": str(uuid.uuid4()),
-            "timestamp": detection.frame_timestamp,
+            "timestamp": datetime.fromtimestamp(detection.frame_timestamp, tz=UTC)
+            .isoformat()
+            .replace("+00:00", "Z"),
             "vehicleId": vehicle_id,
             "vehicleType": detection.vehicle_type.value,
             "movement": {


### PR DESCRIPTION
Fix timestamp format mismatch between EventGenerator and API contract:

**Problem:**
- EventGenerator.create_vehicle_event() produced float Unix timestamps
- API contract requires string timestamps in ISO 8601 format
- EventDatabase handled both formats, but WebSocket API expected strings
- This would cause runtime errors during real-time event streaming

**Solution:**
- Convert detection.frame_timestamp (float) to ISO format string with Z suffix
- Use datetime.fromtimestamp(timestamp, tz=UTC).isoformat().replace('+00:00', 'Z')
- Add required datetime imports to main.py

**Result:**
- Timestamps now format: "2025-08-28T07:38:56.983440Z"
- Full compliance with API WebSocket Event Format

**Verification:**
✅ Custom test confirms proper ISO format generation 
✅ MyPy success - no type issues
✅ Ruff clean - all formatting applied