### PR TITLE
fix(logs): Remove remaining track_id references in logging statements

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -244,14 +244,14 @@ class EventDatabase:
                 self.saved_count += 1
 
             logger.debug(
-                f"Vehicle journey {journey.track_id} saved: "
+                f"Vehicle journey {journey.journey_id} saved: "
                 f"{journey.journey_duration_seconds:.1f}s, "
                 f"{journey.total_detections} detections"
             )
             return True
 
         except Exception as e:
-            logger.error(f"Failed to save vehicle journey {journey.track_id}: {e}")
+            logger.error(f"Failed to save vehicle journey {journey.journey_id}: {e}")
             return False
 
     def _save_journey_sync(self, journey_data: tuple, conn: sqlite3.Connection) -> None:

--- a/main.py
+++ b/main.py
@@ -285,7 +285,7 @@ class TrafficMetryProcessor:
             if isinstance(event, VehicleEntered):
                 # Vehicle entered tracking area with dynamic direction detection
                 logger.info(
-                    f"🚗 Vehicle {event.journey_id} (Track {event.track_id}) ({event.vehicle_type}) entered at "
+                    f"🚗 Vehicle {event.journey_id} ({event.vehicle_type}) entered at "
                     f"position ({event.detection.centroid[0]}, {event.detection.centroid[1]})"
                 )
 
@@ -295,7 +295,7 @@ class TrafficMetryProcessor:
             elif isinstance(event, VehicleUpdated):
                 # Vehicle position updated with dynamic direction analysis
                 logger.debug(
-                    f"📍 Vehicle {event.journey_id} (Track {event.track_id}) updated: "
+                    f"📍 Vehicle {event.journey_id} updated: "
                     f"direction {event.movement_direction}, "
                     f"confidence {event.current_confidence:.2f}, "
                     f"detections {event.total_detections_so_far}"
@@ -313,16 +313,16 @@ class TrafficMetryProcessor:
                     if success:
                         self.event_count += 1
                         logger.info(
-                            f"🏁 Vehicle {event.track_id} journey completed and saved: "
+                            f"🏁 Vehicle {journey.journey_id} journey completed and saved: "
                             f"{journey.journey_duration_seconds:.1f}s, "
                             f"{journey.total_detections} detections, "
                             f"best confidence {journey.best_confidence:.2f}"
                         )
                     else:
-                        logger.error(f"Failed to save journey for vehicle {event.track_id}")
+                        logger.error(f"Failed to save journey for vehicle {event.journey_id}")
 
                 except DatabaseError as e:
-                    logger.error(f"Database error saving vehicle {event.track_id} journey: {e}")
+                    logger.error(f"Database error saving vehicle {event.journey_id} journey: {e}")
 
                 # Future: Send WebSocket exit notification
                 # await self._publish_websocket_event(event.to_websocket_format())

--- a/scripts/calibrate.py
+++ b/scripts/calibrate.py
@@ -557,8 +557,10 @@ class CalibrationUI:
             # Allow some tolerance for lines that intersect just outside the frame
             if self.reference_frame is not None:
                 margin = 50  # pixels tolerance outside image bounds
-                if (-margin <= ix <= self.reference_frame.shape[1] + margin and
-                    -margin <= iy <= self.reference_frame.shape[0] + margin):
+                if (
+                    -margin <= ix <= self.reference_frame.shape[1] + margin
+                    and -margin <= iy <= self.reference_frame.shape[0] + margin
+                ):
                     return True
 
         return False

--- a/scripts/diagnostics_viewer.py
+++ b/scripts/diagnostics_viewer.py
@@ -681,7 +681,7 @@ class GUIThread:
 
             # Add labels based on thread-safe control state
             if control_state.show_track_ids and hasattr(detection, "track_id"):
-                label = f"ID: {detection.track_id}"
+                label = f"Track: {detection.track_id}"
                 cv2.putText(
                     display_frame,
                     label,


### PR DESCRIPTION
Issue: After removing track_id from VehicleJourney model, logs trying to reference event.journey.track_id caused AttributeError, which was incorrectly reported as "Failed to save journey".

Solution:
- main.py: replaced track_id references with journey_id in logs
- database.py: fixed journey saving logs
- diagnostics_viewer.py: minor fixes in track_id display